### PR TITLE
Add scnearios from CLI parameters to dataset versioning

### DIFF
--- a/src/egon/data/datasets/__init__.py
+++ b/src/egon/data/datasets/__init__.py
@@ -213,9 +213,9 @@ class Dataset:
         dependencies = (
             session.query(Model)
             .filter(
-                tuple_(Model.name, Model.version, Model.scenarios).in_(
+                tuple_(Model.name, Model.version).in_(
                     [
-                        (dataset.name, dataset.version, dataset.scenarios)
+                        (dataset.name, dataset.version)
                         for dependency in self.dependencies
                         if isinstance(dependency, Dataset)
                         or hasattr(dependency, "dataset")


### PR DESCRIPTION
Related to #15. 

The changes on this branch ensure that tasks are only skipped if they have been already executed for the dataset version and the list of scenario names from the cli parameters. 
This way we can make sure that we do not get messed up when we run different sets of scenarios. It is currently implemented very simply, as soon as the scenario names from the CLI parameters change (even if there are the same scenario but in another order), no task is skipped. 

Since the structure of the Dataset class is updated in this branch, it is necessary to re-create the database or at least the schema "metadata" once. 
