### PR TITLE
Features/#41 e mobility leftovers

### DIFF
--- a/src/egon/data/datasets.yml
+++ b/src/egon/data/datasets.yml
@@ -1116,6 +1116,9 @@ emobility_mit:
         columns: "D, J:N"
         skiprows: 8
       trips:
+        status2019:
+          file:  "eGon2035_RS7_min2k_2022-06-01_175429_simbev_run.tar.gz"
+          file_metadata: "metadata_simbev_run.json"
         eGon2035:
           file: "eGon2035_RS7_min2k_2022-06-01_175429_simbev_run.tar.gz"
           file_metadata: "metadata_simbev_run.json"

--- a/src/egon/data/datasets/emobility/motorized_individual_travel/__init__.py
+++ b/src/egon/data/datasets/emobility/motorized_individual_travel/__init__.py
@@ -242,7 +242,7 @@ def extract_trip_file():
     """Extract trip file from data bundle"""
     trip_dir = DATA_BUNDLE_DIR / Path("mit_trip_data")
 
-    for scenario_name in ["eGon2035", "eGon100RE"]:
+    for scenario_name in ["status2019", "eGon2035", "eGon100RE"]:
         print(f"SCENARIO: {scenario_name}")
         trip_file = trip_dir / Path(
             DATASET_CFG["original_data"]["sources"]["trips"][scenario_name][
@@ -270,7 +270,7 @@ def write_evs_trips_to_db():
         df["simbev_ev_id"] = "_".join(f.name.split("_")[0:3])
         return df
 
-    for scenario_name in ["eGon2035", "eGon100RE"]:
+    for scenario_name in ["status2019", "eGon2035", "eGon100RE"]:
         print(f"SCENARIO: {scenario_name}")
         trip_dir_name = Path(
             DATASET_CFG["original_data"]["sources"]["trips"][scenario_name][
@@ -377,7 +377,7 @@ def write_metadata_to_db():
         "grid_timeseries_by_usecase": bool,
     }
 
-    for scenario_name in ["eGon2035", "eGon100RE"]:
+    for scenario_name in ["status2019", "eGon2035", "eGon100RE"]:
         meta_run_config = read_simbev_metadata_file(
             scenario_name, "config"
         ).loc["basic"]

--- a/src/egon/data/datasets/emobility/motorized_individual_travel/__init__.py
+++ b/src/egon/data/datasets/emobility/motorized_individual_travel/__init__.py
@@ -470,10 +470,10 @@ class MotorizedIndividualTravel(Dataset):
                 allocate_evs_to_grid_districts,
                 delete_model_data_from_db, )
     
-        *generate_model_data_tasks = set()
+        generate_model_data_tasks = set()
         
         for scenario_name in egon.data.config.settings()["egon-data"]["--scenarios"]:
-            *generate_model_data_tasks.add(*generate_model_data_tasks(scenario_name=scenario_name))
+            generate_model_data_tasks.add(generate_model_data_tasks(scenario_name=scenario_name))
             
         tasks = tasks +  ({*generate_model_data_tasks},)
         

--- a/src/egon/data/datasets/emobility/motorized_individual_travel/__init__.py
+++ b/src/egon/data/datasets/emobility/motorized_individual_travel/__init__.py
@@ -454,7 +454,7 @@ class MotorizedIndividualTravel(Dataset):
                 tasks.add(generate_model_data_eGon100RE_remaining)
             return tasks
 
-       tasks = (
+        tasks = (
                 create_tables,
                 {
                     (
@@ -470,12 +470,12 @@ class MotorizedIndividualTravel(Dataset):
                 allocate_evs_to_grid_districts,
                 delete_model_data_from_db, )
     
-        generate_model_data_tasks = set()
+        tasks_per_scenario = set()
         
-        for scenario_name in egon.data.config.settings()["egon-data"]["--scenarios"]:
-            generate_model_data_tasks.add(generate_model_data_tasks(scenario_name=scenario_name))
+        for scenario_name in config.settings()["egon-data"]["--scenarios"]:
+            tasks_per_scenario.update(generate_model_data_tasks(scenario_name=scenario_name))
             
-        tasks = tasks +  ({*generate_model_data_tasks},)
+        tasks = tasks +  (tasks_per_scenario,)
         
         super().__init__(
             name="MotorizedIndividualTravel",

--- a/src/egon/data/datasets/emobility/motorized_individual_travel/__init__.py
+++ b/src/egon/data/datasets/emobility/motorized_individual_travel/__init__.py
@@ -242,7 +242,7 @@ def extract_trip_file():
     """Extract trip file from data bundle"""
     trip_dir = DATA_BUNDLE_DIR / Path("mit_trip_data")
 
-    for scenario_name in ["status2019", "eGon2035", "eGon100RE"]:
+    for scenario_name in egon.data.config.settings()["egon-data"]["--scenarios"]:
         print(f"SCENARIO: {scenario_name}")
         trip_file = trip_dir / Path(
             DATASET_CFG["original_data"]["sources"]["trips"][scenario_name][
@@ -270,7 +270,7 @@ def write_evs_trips_to_db():
         df["simbev_ev_id"] = "_".join(f.name.split("_")[0:3])
         return df
 
-    for scenario_name in ["status2019", "eGon2035", "eGon100RE"]:
+    for scenario_name in egon.data.config.settings()["egon-data"]["--scenarios"]:
         print(f"SCENARIO: {scenario_name}")
         trip_dir_name = Path(
             DATASET_CFG["original_data"]["sources"]["trips"][scenario_name][
@@ -377,7 +377,7 @@ def write_metadata_to_db():
         "grid_timeseries_by_usecase": bool,
     }
 
-    for scenario_name in ["status2019", "eGon2035", "eGon100RE"]:
+    for scenario_name in egon.data.config.settings()["egon-data"]["--scenarios"]:
         meta_run_config = read_simbev_metadata_file(
             scenario_name, "config"
         ).loc["basic"]
@@ -448,17 +448,13 @@ class MotorizedIndividualTravel(Dataset):
 
             if scenario_name == "status2019":
                 tasks.add(generate_model_data_status2019_remaining)
-            if scenario_name == "eGon2035":
+            elif scenario_name == "eGon2035":
                 tasks.add(generate_model_data_eGon2035_remaining)
             elif scenario_name == "eGon100RE":
                 tasks.add(generate_model_data_eGon100RE_remaining)
             return tasks
 
-        super().__init__(
-            name="MotorizedIndividualTravel",
-            version="0.0.7",
-            dependencies=dependencies,
-            tasks=(
+       tasks = (
                 create_tables,
                 {
                     (
@@ -472,11 +468,18 @@ class MotorizedIndividualTravel(Dataset):
                     ),
                 },
                 allocate_evs_to_grid_districts,
-                delete_model_data_from_db,
-                {
-                    *generate_model_data_tasks(scenario_name="status2019"),
-                    *generate_model_data_tasks(scenario_name="eGon2035"),
-                    *generate_model_data_tasks(scenario_name="eGon100RE"),
-                },
-            ),
+                delete_model_data_from_db, )
+    
+        *generate_model_data_tasks = set()
+        
+        for scenario_name in egon.data.config.settings()["egon-data"]["--scenarios"]:
+            *generate_model_data_tasks.add(*generate_model_data_tasks(scenario_name=scenario_name))
+            
+        tasks = tasks +  ({*generate_model_data_tasks},)
+        
+        super().__init__(
+            name="MotorizedIndividualTravel",
+            version="0.0.7",
+            dependencies=dependencies,
+            tasks=tasks
         )

--- a/src/egon/data/datasets/emobility/motorized_individual_travel/__init__.py
+++ b/src/egon/data/datasets/emobility/motorized_individual_travel/__init__.py
@@ -109,6 +109,7 @@ from egon.data.datasets.emobility.motorized_individual_travel.helpers import (
 from egon.data.datasets.emobility.motorized_individual_travel.model_timeseries import (  # noqa: E501
     delete_model_data_from_db,
     generate_model_data_bunch,
+    generate_model_data_status2019_remaining,
     generate_model_data_eGon100RE_remaining,
     generate_model_data_eGon2035_remaining,
     read_simbev_metadata_file,
@@ -445,6 +446,8 @@ class MotorizedIndividualTravel(Dataset):
                     )
                 )
 
+            if scenario_name == "status2019":
+                tasks.add(generate_model_data_status2019_remaining)
             if scenario_name == "eGon2035":
                 tasks.add(generate_model_data_eGon2035_remaining)
             elif scenario_name == "eGon100RE":
@@ -453,7 +456,7 @@ class MotorizedIndividualTravel(Dataset):
 
         super().__init__(
             name="MotorizedIndividualTravel",
-            version="0.0.6",
+            version="0.0.7",
             dependencies=dependencies,
             tasks=(
                 create_tables,
@@ -471,6 +474,7 @@ class MotorizedIndividualTravel(Dataset):
                 allocate_evs_to_grid_districts,
                 delete_model_data_from_db,
                 {
+                    *generate_model_data_tasks(scenario_name="status2019"),
                     *generate_model_data_tasks(scenario_name="eGon2035"),
                     *generate_model_data_tasks(scenario_name="eGon100RE"),
                 },

--- a/src/egon/data/datasets/emobility/motorized_individual_travel/__init__.py
+++ b/src/egon/data/datasets/emobility/motorized_individual_travel/__init__.py
@@ -82,7 +82,7 @@ from psycopg2.extensions import AsIs, register_adapter
 import numpy as np
 import pandas as pd
 
-from egon.data import db, subprocess
+from egon.data import config, db, subprocess
 from egon.data.datasets import Dataset
 from egon.data.datasets.emobility.motorized_individual_travel.db_classes import (  # noqa: E501
     EgonEvCountMunicipality,
@@ -242,7 +242,7 @@ def extract_trip_file():
     """Extract trip file from data bundle"""
     trip_dir = DATA_BUNDLE_DIR / Path("mit_trip_data")
 
-    for scenario_name in egon.data.config.settings()["egon-data"]["--scenarios"]:
+    for scenario_name in config.settings()["egon-data"]["--scenarios"]:
         print(f"SCENARIO: {scenario_name}")
         trip_file = trip_dir / Path(
             DATASET_CFG["original_data"]["sources"]["trips"][scenario_name][
@@ -270,7 +270,7 @@ def write_evs_trips_to_db():
         df["simbev_ev_id"] = "_".join(f.name.split("_")[0:3])
         return df
 
-    for scenario_name in egon.data.config.settings()["egon-data"]["--scenarios"]:
+    for scenario_name in config.settings()["egon-data"]["--scenarios"]:
         print(f"SCENARIO: {scenario_name}")
         trip_dir_name = Path(
             DATASET_CFG["original_data"]["sources"]["trips"][scenario_name][
@@ -377,7 +377,7 @@ def write_metadata_to_db():
         "grid_timeseries_by_usecase": bool,
     }
 
-    for scenario_name in egon.data.config.settings()["egon-data"]["--scenarios"]:
+    for scenario_name in config.settings()["egon-data"]["--scenarios"]:
         meta_run_config = read_simbev_metadata_file(
             scenario_name, "config"
         ).loc["basic"]

--- a/src/egon/data/datasets/emobility/motorized_individual_travel/model_timeseries.py
+++ b/src/egon/data/datasets/emobility/motorized_individual_travel/model_timeseries.py
@@ -745,6 +745,12 @@ def write_model_data_to_db(
                     hourly_load_time_series_df.driving_load_time_series.to_list()  # noqa: E501
                 ),
             )
+        elif scenario_name=='status2019':
+            write_load(
+                scenario_name=scenario_name,
+                connection_bus_id=etrago_bus.bus_id,
+                load_ts=hourly_load_time_series_df.load_time_series.to_list(),
+            )
         else:
             # Get lowflex scenario name
             lowflex_scenario_name = DATASET_CFG["scenario"]["lowflex"][

--- a/src/egon/data/datasets/emobility/motorized_individual_travel/model_timeseries.py
+++ b/src/egon/data/datasets/emobility/motorized_individual_travel/model_timeseries.py
@@ -1058,6 +1058,14 @@ def generate_model_data_bunch(scenario_name: str, bunch: range) -> None:
             bat_cap=meta_tech_data.battery_capacity,
         )
 
+def generate_model_data_status2019_remaining():
+    """Generates timeseries for status2019 scenario for grid districts which
+    has not been processed in the parallel tasks before.
+    """
+    generate_model_data_bunch(
+        scenario_name="status2019",
+        bunch=range(MVGD_MIN_COUNT, len(load_grid_district_ids())),
+    )
 
 def generate_model_data_eGon2035_remaining():
     """Generates timeseries for eGon2035 scenario for grid districts which


### PR DESCRIPTION
Fixes #41. For simbev, we take the eGon2035 data for now. I will create an issue to address that task in the near future...
It is not tested yet - but I think the changes are small enough to give it a try without testing it :smirk: 

## Before merging into `dev`-branch, please make sure that

- [ ] the `CHANGELOG.rst` was updated.
- [ ] new and adjusted code is formated using `black` and `isort`.
- [ ] the `Dataset`-version is updated when existing datasets are adjusted.
- [ ] the branch was merged into the
      `continuous-integration/run-everything-over-the-weekend`-branch.
- [ ] the workflow is running successful in `test mode`.
- [ ] the workflow is running successful in `Everything` mode.
