### PR TITLE
Features/#61 power plants scenario name

### DIFF
--- a/src/egon/data/airflow/dags/pipeline.py
+++ b/src/egon/data/airflow/dags/pipeline.py
@@ -581,7 +581,7 @@ with airflow.DAG(
             heat_supply,
             heat_time_series,
             heat_pumps_pypsa_eur_sec,
-            tasks["power_plants.pv_rooftop_buildings.pv-rooftop-to-buildings"],
+            power_plants,
         ]
     )
 

--- a/src/egon/data/airflow/dags/pipeline_status_quo.py
+++ b/src/egon/data/airflow/dags/pipeline_status_quo.py
@@ -455,7 +455,7 @@ with airflow.DAG(
             DistrictHeatingAreas,
             heat_supply,
             heat_time_series,
-            tasks["power_plants.pv_rooftop_buildings.pv-rooftop-to-buildings"],
+            power_plants,
         ]
     )
 

--- a/src/egon/data/datasets/power_plants/assign_weather_data.py
+++ b/src/egon/data/datasets/power_plants/assign_weather_data.py
@@ -3,7 +3,71 @@ import pandas as pd
 
 from egon.data import db
 import egon.data.config
-import egon.data.datasets.power_plants.__init__ as init_pp
+
+
+def assign_bus_id(power_plants, cfg):
+    """Assigns bus_ids to power plants according to location and voltage level
+
+    Parameters
+    ----------
+    power_plants : pandas.DataFrame
+        Power plants including voltage level
+
+    Returns
+    -------
+    power_plants : pandas.DataFrame
+        Power plants including voltage level and bus_id
+
+    """
+
+    mv_grid_districts = db.select_geodataframe(
+        f"""
+        SELECT * FROM {cfg['sources']['egon_mv_grid_district']}
+        """,
+        epsg=4326,
+    )
+
+    ehv_grid_districts = db.select_geodataframe(
+        f"""
+        SELECT * FROM {cfg['sources']['ehv_voronoi']}
+        """,
+        epsg=4326,
+    )
+
+    # Assign power plants in hv and below to hvmv bus
+    power_plants_hv = power_plants[power_plants.voltage_level >= 3].index
+    if len(power_plants_hv) > 0:
+        power_plants.loc[power_plants_hv, "bus_id"] = gpd.sjoin(
+            power_plants[power_plants.index.isin(power_plants_hv)],
+            mv_grid_districts,
+        ).bus_id
+
+    # Assign power plants in ehv to ehv bus
+    power_plants_ehv = power_plants[power_plants.voltage_level < 3].index
+
+    if len(power_plants_ehv) > 0:
+        ehv_join = gpd.sjoin(
+            power_plants[power_plants.index.isin(power_plants_ehv)],
+            ehv_grid_districts,
+        )
+
+        if "bus_id_right" in ehv_join.columns:
+            power_plants.loc[power_plants_ehv, "bus_id"] = gpd.sjoin(
+                power_plants[power_plants.index.isin(power_plants_ehv)],
+                ehv_grid_districts,
+            ).bus_id_right
+
+        else:
+            power_plants.loc[power_plants_ehv, "bus_id"] = gpd.sjoin(
+                power_plants[power_plants.index.isin(power_plants_ehv)],
+                ehv_grid_districts,
+            ).bus_id
+
+    # Assert that all power plants have a bus_id
+    assert power_plants.bus_id.notnull().all(), f"""Some power plants are
+    not attached to a bus: {power_plants[power_plants.bus_id.isnull()]}"""
+
+    return power_plants
 
 
 def weatherId_and_busId():
@@ -20,9 +84,7 @@ def find_bus_id(power_plants, cfg):
     power_plants_no_busId = power_plants_no_busId.drop(columns="bus_id")
 
     if len(power_plants_no_busId) > 0:
-        power_plants_no_busId = init_pp.assign_bus_id(
-            power_plants_no_busId, cfg
-        )
+        power_plants_no_busId = assign_bus_id(power_plants_no_busId, cfg)
 
     power_plants = power_plants.append(power_plants_no_busId)
 
@@ -105,7 +167,6 @@ def find_weather_id():
 
 
 def write_power_plants_table(power_plants, cfg, con):
-
     # delete weather dependent power_plants from supply.egon_power_plants
     db.execute_sql(
         f"""


### PR DESCRIPTION
Fixes #61 .

On this branch, the power_plants dataset is filled with tasks depending on the list of scenario names. E.g. in case no future scenario is selected, all the tasks that expand power plants are not executed and are not part of the pipeline. 

The task pv_rooftop_buildings is also only needed when future scenarios are created. Before, the heatpumps datasets directly referred to that tasks, which is not possible if the task is not there. To fix this, I changed the dependency to the whole power_plants dataset, which results in a bit fewer parallel tasks. But those tasks are quite fast, so I guess we can accept that. 

@CarlosEpia: I already tested that it works. For me, it would be enough if you have a brief look at the code. 