### PR TITLE
Replace hard-coded scenario names

### DIFF
--- a/src/egon/data/datasets/electricity_demand/temporal.py
+++ b/src/egon/data/datasets/electricity_demand/temporal.py
@@ -215,7 +215,7 @@ def insert_cts_load():
 
     create_table()
 
-    for scenario in ["eGon2035", "eGon100RE"]:
+    for scenario in egon.data.config.settings()["egon-data"]["--scenarios"]:
 
         # Delete existing data from database
         db.execute_sql(

--- a/src/egon/data/datasets/heat_demand_timeseries/idp_pool.py
+++ b/src/egon/data/datasets/heat_demand_timeseries/idp_pool.py
@@ -362,7 +362,7 @@ def create():
     return idp_df
 
 
-def annual_demand_generator():
+def annual_demand_generator(scenario):
     """
 
     Description: Create dataframe with annual demand and household count for each zensus cell
@@ -374,7 +374,6 @@ def annual_demand_generator():
 
     """
 
-    scenario = "eGon2035"
     demand_zone = db.select_dataframe(
         f"""
         SELECT a.demand, a.zensus_population_id, a.scenario, c.climate_zone
@@ -463,7 +462,9 @@ def select():
     )
 
     # Calculate annual heat demand per census cell
-    annual_demand = annual_demand_generator()
+    annual_demand = annual_demand_generator(
+        scenario = egon.data.config.settings()["egon-data"]["--scenarios"][0]
+        )
 
     # Count number of SFH and MFH per climate zone
     houses_per_climate_zone = (


### PR DESCRIPTION
Fixes remaining lines with hard-coded scenario names. 
Some of the changes are already part of the current run, others are actually not used for the status2019 scenario.

I kept some datasets unchanged since we are not using them in the status2019 pipeline, these are:

- sanity checks
- low flex scenario
- DSM
- industrial_gas_demand
- gas_neighbours