### PR TITLE
Fixes/#159 mastr on zenodo

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -729,6 +729,7 @@ Bug Fixes
   `#1098 <https://github.com/openego/eGon-data/issues/1098>`_
 * Fix conversion factor for CH4 loads abroad in eGon2035
   `#1104 <https://github.com/openego/eGon-data/issues/1104>`_
+* Fix URLs of MaStR datasets
 
 .. _PR #692: https://github.com/openego/eGon-data/pull/692
 .. _#343: https://github.com/openego/eGon-data/issues/343

--- a/src/egon/data/datasets.yml
+++ b/src/egon/data/datasets.yml
@@ -295,7 +295,7 @@ mastr:
     - "gsgk"
     - "storage"
   file_basename: "bnetza_mastr"
-  deposit_id: 808086
+  deposit_id: 10480930
 
 mastr_new:
   technologies:
@@ -306,7 +306,7 @@ mastr_new:
     - "combustion"
     - "nuclear"
   file_basename: "bnetza_mastr"
-  deposit_id: 1132987
+  deposit_id: 10480958
   egon2021_date_max: "2021-12-31 23:59:00"
   status2019_date_max: "2019-12-31 23:59:00"
 

--- a/src/egon/data/datasets/mastr.py
+++ b/src/egon/data/datasets/mastr.py
@@ -2,15 +2,15 @@
 Download Marktstammdatenregister (MaStR) datasets unit registry.
 It incorporates two different datasets:
 
-Dump 2021-05-03
-* Source: https://sandbox.zenodo.org/record/808086
+Dump 2021-04-30
+* Source: https://zenodo.org/records/10480930
 * Used technologies: PV plants, wind turbines, biomass, hydro plants,
   combustion, nuclear, gsgk, storage
 * Data is further processed in dataset
   :py:class:`egon.data.datasets.power_plants.PowerPlants`
 
 Dump 2022-11-17
-* Source: https://sandbox.zenodo.org/record/1132839
+* Source: https://zenodo.org/records/10480958
 * Used technologies: PV plants, wind turbines, biomass, hydro plants
 * Data is further processed in module
   :py:mod:`egon.data.datasets.power_plants.mastr` `PowerPlants`
@@ -39,7 +39,7 @@ def download_mastr_data():
         # Get parameters from config and set download URL
         data_config = egon.data.config.datasets()[dataset_name]
         zenodo_files_url = (
-            f"https://sandbox.zenodo.org/record/"
+            f"https://zenodo.org/record/"
             f"{data_config['deposit_id']}/files/"
         )
 

--- a/src/egon/data/datasets/mastr.py
+++ b/src/egon/data/datasets/mastr.py
@@ -69,7 +69,7 @@ def download_mastr_data():
 mastr_data_setup = partial(
     Dataset,
     name="MastrData",
-    version="0.0.1",
+    version="0.0.2",
     dependencies=[],
     tasks=(download_mastr_data,),
 )

--- a/src/egon/data/datasets_original.yml
+++ b/src/egon/data/datasets_original.yml
@@ -295,7 +295,7 @@ mastr:
     - "gsgk"
     - "storage"
   file_basename: "bnetza_mastr"
-  deposit_id: 808086
+  deposit_id: 10480930
 
 mastr_new:
   technologies:
@@ -304,7 +304,7 @@ mastr_new:
     - "solar"
     - "biomass"
   file_basename: "bnetza_mastr"
-  deposit_id: 1132987
+  deposit_id: 10480958
 
 re_potential_areas:
   target:


### PR DESCRIPTION
Finally fixes #159

Mastr datasets re-uploaded to Zenodo and pipeline adjusted (datasets and datasets_original).
Haven't tested in powerd but successfully tested the download in eGon-data, cf. https://github.com/openego/eGon-data/pull/1158

One reviewer is enough. Thank you!

## Before merging into `dev`-branch, please make sure that

- [x] the `CHANGELOG.rst` was updated.
- [x] new and adjusted code is formated using `black` and `isort`.
- [x] the `Dataset`-version is updated when existing datasets are adjusted.
- [ ] the branch was merged into the
      `continuous-integration/run-everything-over-the-weekend`-branch.
- [ ] the workflow is running successful in `test mode`.
- [ ] the workflow is running successful in `Everything` mode.
