### PR TITLE
Fixes/#179 era5 crs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -729,6 +729,8 @@ Bug Fixes
   `#1098 <https://github.com/openego/eGon-data/issues/1098>`_
 * Fix conversion factor for CH4 loads abroad in eGon2035
   `#1104 <https://github.com/openego/eGon-data/issues/1104>`_
+* Fix CRS in ERA5 transformation
+  `#179 <https://github.com/openego/powerd-data/issues/179>`_
 
 .. _PR #692: https://github.com/openego/eGon-data/pull/692
 .. _#343: https://github.com/openego/eGon-data/issues/343

--- a/src/egon/data/datasets/era5.py
+++ b/src/egon/data/datasets/era5.py
@@ -81,7 +81,7 @@ def import_cutout(boundary="Europe"):
                 "SELECT geometry as geom FROM boundaries.vg250_sta_bbox",
                 db.engine(),
             )
-            .to_crs(4623)
+            .to_crs(4326)
             .geom
         )
         xs = slice(geom_de.bounds.minx[0], geom_de.bounds.maxx[0])


### PR DESCRIPTION
Fixes #179 

## Before merging into `dev`-branch, please make sure that

- [x] the `CHANGELOG.rst` was updated.
- [ ] new and adjusted code is formated using `black` and `isort`.
- [ ] the `Dataset`-version is updated when existing datasets are adjusted.
- [ ] the branch was merged into the
      `continuous-integration/run-everything-over-the-weekend`-branch.
- [ ] the workflow is running successful in `test mode`.
- [ ] the workflow is running successful in `Everything` mode.
