### PR TITLE
Use cached DemandRegio tables and scale status2023 cts & ind

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -260,6 +260,8 @@ Added
   `#168 <https://github.com/openego/powerd-data/pull/168>`_
 * Update osm for status2023
   `#169 <https://github.com/openego/powerd-data/pull/169>`_
+* Use cached DemandRegio tables for status2023
+  `#185 <https://github.com/openego/powerd-data/pull/185>`_
 
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -260,7 +260,7 @@ Added
   `#168 <https://github.com/openego/powerd-data/pull/168>`_
 * Update osm for status2023
   `#169 <https://github.com/openego/powerd-data/pull/169>`_
-* Use cached DemandRegio tables for status2023
+* Use cached DemandRegio tables and scale status2023 cts & ind
   `#185 <https://github.com/openego/powerd-data/pull/185>`_
 
 

--- a/src/egon/data/datasets.yml
+++ b/src/egon/data/datasets.yml
@@ -94,6 +94,12 @@ demandregio_installation:
   targets:
     path: 'demandregio-disaggregator'
 
+demandregio_workaround:
+  source:
+    url: "https://wolke.rl-institut.de/s/FqzCXNnPgGeRykk/download/__cache__.zip"
+  targets:
+    path: 'demandregio-disaggregator/disaggregator/disaggregator/data_in/'
+
 demandregio_society:
   sources:
     disaggregator:

--- a/src/egon/data/datasets.yml
+++ b/src/egon/data/datasets.yml
@@ -96,10 +96,15 @@ demandregio_installation:
 
 demandregio_workaround:
   source:
-    url: "https://wolke.rl-institut.de/s/FqzCXNnPgGeRykk/download/__cache__.zip"
+    cache:
+      url: "https://wolke.rl-institut.de/s/FqzCXNnPgGeRykk/download/__cache__.zip"
+    dbdump:
+      url: "https://wolke.rl-institut.de/s/7Z9m9q7JiP6HC6k/download/status2019-egon_demandregio_cts_ind.zip"
   targets:
-    path: 'demandregio-disaggregator/disaggregator/disaggregator/data_in/'
-
+    cache:
+      path: 'demandregio-disaggregator/disaggregator/disaggregator/data_in/'
+    dbdump:
+      path: "demandregio_dbdump"
 demandregio_society:
   sources:
     disaggregator:

--- a/src/egon/data/datasets/demandregio/__init__.py
+++ b/src/egon/data/datasets/demandregio/__init__.py
@@ -555,7 +555,7 @@ def insert_cts_ind(scenario, year, engine, target_values):
         # scale values according to target_values
         if sector in target_values[scenario].keys():
             ec_cts_ind *= (
-                target_values[scenario][sector] * 1e3 / ec_cts_ind.sum().sum()
+                target_values[scenario][sector] / ec_cts_ind.sum().sum()
             )
 
         # include new largescale consumers according to NEP 2021
@@ -649,11 +649,16 @@ def insert_cts_ind_demands():
         target_values = {
             # according to NEP 2021
             # new consumers will be added seperatly
-            "eGon2035": {"CTS": 135300, "industry": 225400},
+            "eGon2035": {
+                "CTS": 135300 * 1e3,
+                "industry": 225400 * 1e3
+            },
             # CTS: reduce overall demand from demandregio (without traffic)
             # by share of heat according to JRC IDEES, data from 2011
             # industry: no specific heat demand, use data from demandregio
-            "eGon100RE": {"CTS": (1 - (5.96 + 6.13) / 154.64) * 125183.403},
+            "eGon100RE": {
+                "CTS": ((1 - (5.96 + 6.13) / 154.64) * 125183.403) * 1e3
+            },
             # no adjustments for status quo
             "eGon2021": {},
             "status2019": {},

--- a/src/egon/data/datasets/demandregio/__init__.py
+++ b/src/egon/data/datasets/demandregio/__init__.py
@@ -3,6 +3,8 @@ adjusting data from demandRegio
 
 """
 from pathlib import Path
+import os
+import zipfile
 
 from sqlalchemy import ARRAY, Column, Float, ForeignKey, Integer, String
 from sqlalchemy.ext.declarative import declarative_base
@@ -18,6 +20,7 @@ from egon.data.datasets.scenario_parameters import (
     EgonScenario,
     get_sector_parameters,
 )
+from egon.data.datasets.zensus import download_and_check
 import egon.data.config
 import egon.data.datasets.scenario_parameters.parameters as scenario_parameters
 
@@ -807,3 +810,14 @@ def timeseries_per_wz():
     for year in years:
         for sector in ["CTS", "industry"]:
             insert_timeseries_per_wz(sector, int(year))
+
+
+def get_cached_tables():
+    """Get cached demandregio tabel from former runs"""
+    data_config = egon.data.config.datasets()
+    cache_url = data_config["demandregio_workaround"]["source"]["url"]
+    target_path = data_config["demandregio_workaround"]["targets"]["path"]
+    cache_path = Path(".", target_path, "__cache__.zip").resolve()
+    download_and_check(cache_url, cache_path, max_iteration=5)
+    with zipfile.ZipFile(cache_path, "r") as zip_ref:
+        zip_ref.extractall(cache_path.parent)

--- a/src/egon/data/datasets/demandregio/__init__.py
+++ b/src/egon/data/datasets/demandregio/__init__.py
@@ -37,19 +37,36 @@ Base = declarative_base()
 
 class DemandRegio(Dataset):
     def __init__(self, dependencies):
+        scale_sq19_cts_status2023 = wrapped_partial(  # adhoc workaround #180
+            scale_sq19,
+            annual_sum=121160 * 1e3,  # BDEW2023 Stromverbrauch vorläufig
+            sector="'CTS'",
+            scn="'status2023'",
+            postfix="_cts_status2023")
+        scale_sq19_ind_status2023 = wrapped_partial(
+            scale_sq19,
+            annual_sum=200380 * 1e3,
+            sector="'industry'",
+            scn="'status2023'",
+            postfix="_ind_status2023")
+
         super().__init__(
             name="DemandRegio",
             version="0.0.7",
             dependencies=dependencies,
             tasks=(
                 clone_and_install,
-                get_cached_tables,
+                get_cached_tables,  # adhoc workaround #180
                 create_tables,
                 {
                     insert_household_demand,
                     insert_society_data,
-                    insert_cts_ind_demands,
+                    # insert_cts_ind_demands,
+                    (backup_tables_to_db,  # adhoc workaround #180
+                     scale_sq19_cts_status2023,
+                     scale_sq19_ind_status2023,)
                 },
+
             ),
         )
 

--- a/src/egon/data/datasets/demandregio/__init__.py
+++ b/src/egon/data/datasets/demandregio/__init__.py
@@ -679,6 +679,10 @@ def insert_cts_ind_demands():
             # no adjustments for status quo
             "eGon2021": {},
             "status2019": {},
+            # "status2023": {
+            # "CTS": 121160 * 1e3,
+            # "industry": 200380 * 1e3
+            # }, # TODO status2023
         }
 
         insert_cts_ind(scn, year, engine, target_values)

--- a/src/egon/data/datasets/demandregio/__init__.py
+++ b/src/egon/data/datasets/demandregio/__init__.py
@@ -42,6 +42,7 @@ class DemandRegio(Dataset):
             dependencies=dependencies,
             tasks=(
                 clone_and_install,
+                get_cached_tables,
                 create_tables,
                 {
                     insert_household_demand,

--- a/src/egon/data/datasets/demandregio/__init__.py
+++ b/src/egon/data/datasets/demandregio/__init__.py
@@ -38,7 +38,7 @@ class DemandRegio(Dataset):
     def __init__(self, dependencies):
         super().__init__(
             name="DemandRegio",
-            version="0.0.6",
+            version="0.0.7",
             dependencies=dependencies,
             tasks=(
                 clone_and_install,


### PR DESCRIPTION
Fixes #164 .

We found that formerly cached tables can be used in DemandRegio and Industrial Gas demand. The latter is not necessary for StatusQuo2023 as in [Status2019](https://github.com/openego/powerd-data/issues/22#issuecomment-1531067529)

<s>We were not able to find raw data in the cache for these tables:
- demand.egon_demandregio_timeseries_cts_ind
- demand.egon_demandregio_cts_ind

These will be reproduced from database backups </s>

Further missing tables could be reproduces from demandregio db backup. Tabls do only exist for 2017 though but were named 2019


## Before merging into `dev`-branch, please make sure that

- [x] the `CHANGELOG.rst` was updated.
- [x] new and adjusted code is formated using `black` and `isort`.
- [x] the `Dataset`-version is updated when existing datasets are adjusted.
- [ ] the branch was merged into the
      `continuous-integration/run-everything-over-the-weekend`-branch.
- [ ] the workflow is running successful in `test mode`.
- [ ] the workflow is running successful in `Everything` mode.
