### PR TITLE
Add status2023 scenario of demandregio households

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -260,6 +260,8 @@ Added
   `#168 <https://github.com/openego/powerd-data/pull/168>`_
 * Update osm for status2023
   `#169 <https://github.com/openego/powerd-data/pull/169>`_
+* Add status2023 scenario of demandregio households
+  `#186 <https://github.com/openego/powerd-data/pull/186>`_
 
 
 

--- a/src/egon/data/datasets/demandregio/__init__.py
+++ b/src/egon/data/datasets/demandregio/__init__.py
@@ -35,7 +35,7 @@ class DemandRegio(Dataset):
     def __init__(self, dependencies):
         super().__init__(
             name="DemandRegio",
-            version="0.0.6",
+            version="0.0.7",
             dependencies=dependencies,
             tasks=(
                 clone_and_install,

--- a/src/egon/data/datasets/demandregio/__init__.py
+++ b/src/egon/data/datasets/demandregio/__init__.py
@@ -452,7 +452,7 @@ def disagg_households_power(
         df = data.households_per_size(year=year) * power_per_HH
 
     # Bottom-Up: Power demand by household sizes in [MWh/a] for each scenario
-    if scenario in ["status2019", "eGon2021", "eGon2035"]:
+    elif scenario in ["status2019", "status2023", "eGon2021", "eGon2035"]:
         # chose demand per household size from survey including weighted DHW
         power_per_HH = demand_per_hh_size["weighted"] / 1e3
 
@@ -466,7 +466,14 @@ def disagg_households_power(
             # scale to fit demand of NEP 2021 scebario C 2035 (119TWh)
             df *= 119 * 1e6 / df.sum().sum()
 
+        if scenario == "status2023":
+            # scale to fit demand of BDEW 2023 (130.48 TWh) see issue #180
+            df *= 130.48 * 1e6 / df.sum().sum()
 
+        # if scenario == "status2021": # TODO status2021
+        #     # scale to fit demand of AGEB 2021 (138.6 TWh)
+        #     # https://ag-energiebilanzen.de/wp-content/uploads/2023/01/AGEB_22p2_rev-1.pdf#page=10
+        #     df *= 138.6 * 1e6 / df.sum().sum()
 
 
     else:

--- a/src/egon/data/datasets/demandregio/__init__.py
+++ b/src/egon/data/datasets/demandregio/__init__.py
@@ -438,7 +438,9 @@ def disagg_households_power(
 
     if scenario == "eGon100RE":
         # chose demand per household size from survey without DHW
-        power_per_HH = demand_per_hh_size["without_DHW"] / 1e3 # TODO why without?
+        power_per_HH = (
+            demand_per_hh_size["without_DHW"] / 1e3
+        )  # TODO why without?
 
         # calculate demand per nuts3 in 2011
         df_2011 = data.households_per_size(year=2011) * power_per_HH
@@ -474,7 +476,6 @@ def disagg_households_power(
         #     # scale to fit demand of AGEB 2021 (138.6 TWh)
         #     # https://ag-energiebilanzen.de/wp-content/uploads/2023/01/AGEB_22p2_rev-1.pdf#page=10
         #     df *= 138.6 * 1e6 / df.sum().sum()
-
 
     else:
         print(
@@ -611,7 +612,7 @@ def insert_household_demand():
 
     scenarios = egon.data.config.settings()["egon-data"]["--scenarios"]
 
-    scenarios.append("eGon2021") # TODO why is this always appended?
+    scenarios.append("eGon2021")  # TODO why is this always appended?
 
     for t in targets:
         db.execute_sql(

--- a/src/egon/data/datasets/scenario_parameters/parameters.py
+++ b/src/egon/data/datasets/scenario_parameters/parameters.py
@@ -123,6 +123,35 @@ def global_settings(scenario):
             "weather_year": 2011,
             "population_year": 2021,
         }
+    elif scenario == "status2023":
+        parameters = {
+            "weather_year": 2021, # TODO check if possible for 2023
+            "population_year": 2021,  # TODO check maybe possible for 2023 if
+                                        # ffe.opendata is online
+            # "fuel_costs": {
+            #     # TYNDP 2020, data for 2020 (https://2020.entsos-tyndp-scenarios.eu/fuel-commodities-and-carbon-prices/)
+            #     "oil": 12.9 * 3.6,  # [EUR/MWh]
+            #     "gas": 5.6 * 3.6,  # [EUR/MWh]
+            #     "coal": 3.0 * 3.6,  # [EUR/MWh]
+            #     "lignite": 1.1 * 3.6,  # [EUR/MWh]
+            #     "nuclear": 0.47 * 3.6,  # [EUR/MWh]
+            #     "biomass": read_costs(read_csv(2020), "biomass", "fuel"),
+            # },
+            # "co2_costs": 24.7,  # [EUR/t_CO2], source:
+            # # https://de.statista.com/statistik/daten/studie/1304069/umfrage/preisentwicklung-von-co2-emissionsrechten-in-eu/
+            # "co2_emissions": {
+            #     # Netzentwicklungsplan Strom 2035, Version 2021, 1. Entwurf, p. 40, table 8
+            #     "waste": 0.165,  # [t_CO2/MW_th]
+            #     "lignite": 0.393,  # [t_CO2/MW_th]
+            #     "gas": 0.201,  # [t_CO2/MW_th]
+            #     "nuclear": 0.0,  # [t_CO2/MW_th]
+            #     "oil": 0.288,  # [t_CO2/MW_th]
+            #     "coal": 0.335,  # [t_CO2/MW_th]
+            #     "other_non_renewable": 0.268,  # [t_CO2/MW_th]
+            # },
+            # "interest_rate": 0.05,  # [p.u.]
+        }
+
     elif scenario == "status2019":
         parameters = {
             "weather_year": 2019,
@@ -135,7 +164,7 @@ def global_settings(scenario):
                 "nuclear": 0.47*3.6,  # [EUR/MWh]
                 "biomass": read_costs(read_csv(2020), "biomass", "fuel"),
             },
-            "co2_costs": 24.7,  # [EUR/t_CO2], source: 
+            "co2_costs": 24.7,  # [EUR/t_CO2], source:
                 #https://de.statista.com/statistik/daten/studie/1304069/umfrage/preisentwicklung-von-co2-emissionsrechten-in-eu/
             "co2_emissions": {  # Netzentwicklungsplan Strom 2035, Version 2021, 1. Entwurf, p. 40, table 8
                 "waste": 0.165,  # [t_CO2/MW_th]


### PR DESCRIPTION
Fixes #180 .

Update household demand per size: [EnergieAgentur.NRW- Erhebung wo bleibt der Strom?](https://1-stromvergleich.com/wp-content/uploads/erhebung_wo_bleibt_der_strom.pdf)

Add scaling for status2023: [BDEW](https://www.bdew.de/media/documents/Nettostromverbrauch_nach_Verbrauchergruppen_Vgl_10J_o_online_jaehrlich_FS_20122023.pdf)


## Before merging into `dev`-branch, please make sure that

- [x] the `CHANGELOG.rst` was updated.
- [x] new and adjusted code is formated using `black` and `isort`.
- [x] the `Dataset`-version is updated when existing datasets are adjusted.
- [ ] the branch was merged into the
      `continuous-integration/run-everything-over-the-weekend`-branch.
- [ ] the workflow is running successful in `test mode`.
- [ ] the workflow is running successful in `Everything` mode.
