### PR TITLE
Add wrapped_partial to dynamise task generation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -252,6 +252,9 @@ Added
   `PR #903 <https://github.com/openego/eGon-data/pull/903>`_
 * Add low flex scenario 'eGon2035_lowflex'
   `#822 <https://github.com/openego/eGon-data/issues/822>`_
+* Add wrapped_partial to dynamise task generation
+  `#207 <https://github.com/openego/powerd-data/pull/207>`_
+
 
 .. _PR #159: https://github.com/openego/eGon-data/pull/159
 .. _PR #703: https://github.com/openego/eGon-data/pull/703

--- a/src/egon/data/datasets/__init__.py
+++ b/src/egon/data/datasets/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections import abc
 from dataclasses import dataclass
-from functools import reduce
+from functools import partial, reduce, update_wrapper
 from typing import Callable, Iterable, Set, Tuple, Union
 import re
 
@@ -17,6 +17,13 @@ from egon.data import config, db, logger
 
 Base = declarative_base()
 SCHEMA = "metadata"
+
+
+def wrapped_partial(func, *args, **kwargs):
+    partial_func = partial(func, *args, **kwargs)
+    # update partial to look like func
+    update_wrapper(partial_func, func)
+    return partial_func
 
 
 def setup():

--- a/src/egon/data/datasets/__init__.py
+++ b/src/egon/data/datasets/__init__.py
@@ -20,9 +20,14 @@ SCHEMA = "metadata"
 
 
 def wrapped_partial(func, *args, **kwargs):
+    """Like :func:`functools.partial`, but preserves the original function's
+    name and docstring. Also allows to add a postfix to the function's name.
+    """
+    postfix = kwargs.pop("postfix", None)
     partial_func = partial(func, *args, **kwargs)
-    # update partial to look like func
     update_wrapper(partial_func, func)
+    if postfix:
+        partial_func.__name__ = f"{func.__name__}{postfix}"
     return partial_func
 
 


### PR DESCRIPTION
This is a very handy function to dynamise tasks. Application can be seen [here](https://github.com/openego/powerd-data/blob/3eb97577477393ec184395222b11a6356209b4b6/src/egon/data/datasets/gas_grid.py#L1023-L1029) or [here](https://github.com/openego/powerd-data/blob/670c100e66f96d3367735ec6ab494e143ebbbc4c/src/egon/data/datasets/electrical_neighbours.py#L1743-L1773)

## Before merging into `dev`-branch, please make sure that

- [x] the `CHANGELOG.rst` was updated.
- [x] new and adjusted code is formated using `black` and `isort`.
- [ ] the `Dataset`-version is updated when existing datasets are adjusted.
- [ ] the branch was merged into the
      `continuous-integration/run-everything-over-the-weekend`-branch.
- [x] the workflow is running successful in `test mode`.
- [ ] the workflow is running successful in `Everything` mode.
