### PR TITLE
Add optional prefix to config for DAG name

### DIFF
--- a/src/egon/data/airflow/dags/pipeline_status_quo.py
+++ b/src/egon/data/airflow/dags/pipeline_status_quo.py
@@ -3,6 +3,7 @@ import os
 from airflow.utils.dates import days_ago
 import airflow
 
+from egon.data.config import settings as egon_settings
 from egon.data.config import set_numexpr_threads
 from egon.data.datasets import database
 from egon.data.datasets.ch4_prod import CH4Production
@@ -74,10 +75,10 @@ from egon.data.datasets.zensus_vg250 import ZensusVg250
 # Set number of threads used by numpy and pandas
 set_numexpr_threads()
 
-
+prefix = egon_settings()["egon-data"].get("--prefix")
 
 with airflow.DAG(
-    "powerd-status-quo-processing-pipeline",
+    f"{prefix}-powerd-status-quo-processing-pipeline",
     description="The PoWerD Status Quo data processing DAG.",
     default_args={"start_date": days_ago(1),
                   "email_on_failure": False,


### PR DESCRIPTION
This way, multiple airflow instances can be differentiated within airflow platform. This can help, when using multiple instances for parallel development.

![image](https://github.com/openego/powerd-data/assets/51374526/8b25044b-f7f2-45c2-8367-6fa0a35588bc)


## Before merging into `dev`-branch, please make sure that

- [ ] the `CHANGELOG.rst` was updated.
- [ ] new and adjusted code is formated using `black` and `isort`.
- [ ] the `Dataset`-version is updated when existing datasets are adjusted.
- [ ] the branch was merged into the
      `continuous-integration/run-everything-over-the-weekend`-branch.
- [ ] the workflow is running successful in `test mode`.
- [ ] the workflow is running successful in `Everything` mode.
