### PR TITLE
Add download of data bundle for powerd-data

### DIFF
--- a/src/egon/data/datasets.yml
+++ b/src/egon/data/datasets.yml
@@ -558,9 +558,12 @@ data-bundle:
   sources:
     zenodo:
       deposit_id: 10226009
+      deposit_id_powerd: 11618105
   targets:
     file:
       'data_bundle_egon_data.zip'
+    file_powerd:
+      'data_bundle_powerd_data.zip'
 
 pypsa-technology-data:
   sources:

--- a/src/egon/data/datasets/data_bundle/__init__.py
+++ b/src/egon/data/datasets/data_bundle/__init__.py
@@ -33,15 +33,32 @@ def download():
     with zipfile.ZipFile(target_file, "r") as zip_ref:
         zip_ref.extractall(".")
 
+    powerd_data_bundle_path = Path(".") / "data_bundle_powerd_data"
+    # Delete folder if it already exists
+    if powerd_data_bundle_path.exists() and powerd_data_bundle_path.is_dir():
+        shutil.rmtree(powerd_data_bundle_path)
+
+    url = f"""https://sandbox.zenodo.org/record/{sources['deposit_id_powerd']}/files/data_bundle_powerd_data.zip"""
+    target_file = egon.data.config.datasets()["data-bundle"]["targets"]["file_powerd"]
+
+    # Retrieve files
+    urlretrieve(url, target_file)
+
+    with zipfile.ZipFile(target_file, "r") as zip_ref:
+        zip_ref.extractall(".")
+
 
 class DataBundle(Dataset):
     def __init__(self, dependencies):
         deposit_id = egon.data.config.datasets()["data-bundle"]["sources"][
             "zenodo"
         ]["deposit_id"]
+        deposit_id_powerd = egon.data.config.datasets()["data-bundle"]["sources"][
+            "zenodo"
+        ]["deposit_id"]
         super().__init__(
             name="DataBundle",
-            version=str(deposit_id) + "-0.0.2",
+            version=str(deposit_id) + str(deposit_id_powerd) + "-0.0.3",
             dependencies=dependencies,
             tasks=(download),
         )

--- a/src/egon/data/datasets/data_bundle/__init__.py
+++ b/src/egon/data/datasets/data_bundle/__init__.py
@@ -38,7 +38,7 @@ def download():
     if powerd_data_bundle_path.exists() and powerd_data_bundle_path.is_dir():
         shutil.rmtree(powerd_data_bundle_path)
 
-    url = f"""https://sandbox.zenodo.org/record/{sources['deposit_id_powerd']}/files/data_bundle_powerd_data.zip"""
+    url = f"""https://zenodo.org/record/{sources['deposit_id_powerd']}/files/data_bundle_powerd_data.zip"""
     target_file = egon.data.config.datasets()["data-bundle"]["targets"]["file_powerd"]
 
     # Retrieve files


### PR DESCRIPTION
As soon as we published the small data bundle on zenodo, this branch can be merged. 
It includes the code needed to download and process the data. 
I was able to create the deposit id for the draft already, so no further changes should be needed. 