### PR TITLE
Set min_file_process_interval to the default value of Airflow 2

### DIFF
--- a/src/egon/data/airflow/airflow.cfg
+++ b/src/egon/data/airflow/airflow.cfg
@@ -626,7 +626,7 @@ num_runs = -1
 processor_poll_interval = 1
 
 # after how much time (seconds) a new DAGs should be picked up from the filesystem
-min_file_process_interval = 0
+min_file_process_interval = 30
 
 # How often (in seconds) to scan the DAGs directory for new files. Default to 5 minutes.
 dag_dir_list_interval = 300


### PR DESCRIPTION
This should prevent that all CPU cores are used by the scheduler

Fixes #281  .
