### PR TITLE
Fixes/#280 overwritten ch4 foreign buses

### DIFF
--- a/src/egon/data/datasets/pypsaeur/__init__.py
+++ b/src/egon/data/datasets/pypsaeur/__init__.py
@@ -377,11 +377,12 @@ def clean_database():
             ;"""
         )
 
-    db.execute_sql(
-        "DELETE FROM grid.egon_etrago_bus "
-        "WHERE scn_name = '{scn_name}' "
-        "AND country <> 'DE' "
-        "AND carrier <> 'AC'"
+    db.execute_sql(f"""
+        DELETE FROM grid.egon_etrago_bus
+        WHERE scn_name = '{scn_name}'
+        AND country <> 'DE'
+        AND carrier <> 'AC'
+        """
     )
 
 


### PR DESCRIPTION
Fixes #280 partially. This PR was already tested on our server and solved the problem related to links connected to unexisting gas buses. The problem was caused by creating the foreign CH4 buses twice: in insert_gas_data and in electrical_neighbours_egon100.

The proposed solution is based on keeping the buses coming from pypsa-eur, and using them in _insert_gas_data_ when the scenario is eGon100RE