### PR TITLE
Fix incorrect YAML serialization of the `--scenarios` CLI parameter that caused broken DAGs in the pipeline

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -738,6 +738,9 @@ Bug Fixes
   `#179 <https://github.com/openego/powerd-data/issues/179>`_
 * Fix depricated python-operator import
   `#183 <https://github.com/openego/powerd-data/issues/183>`_
+* Fix incorrect YAML serialization of the --scenarios CLI
+  parameter that caused broken DAGs in the pipeline.
+  `#343 <https://github.com/openego/powerd-data/issues/343>`_
 
 
 .. _PR #692: https://github.com/openego/eGon-data/pull/692

--- a/src/egon/data/cli.py
+++ b/src/egon/data/cli.py
@@ -179,6 +179,7 @@ from sqlalchemy.orm import Session
     default=["status2019", "eGon2035"],
     metavar="SCENARIOS",
     help=("List of scenario names for which a data model shall be created."),
+    multiple=True,
     show_default=True,
 )
 @click.option(


### PR DESCRIPTION
Fixes #343  .

## Before merging into `dev`-branch, please make sure that

- [x] the `CHANGELOG.rst` was updated.
- [ ] ~~new and adjusted code is formated using `black` and `isort`.~~
- [ ] ~~the `Dataset`-version is updated when existing datasets are adjusted.~~
- [ ] ~~the branch was merged into the
      `continuous-integration/run-everything-over-the-weekend`-branch.~~
- [ ] ~~the workflow is running successful in `test mode`.~~
- [ ] ~~the workflow is running successful in `Everything` mode.~~
