### PR TITLE
Fixes/#350 osm bld load assignment

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -264,6 +264,8 @@ Added
   `#207 <https://github.com/openego/powerd-data/pull/207>`_
 * Add MaStR geocoding and handling of conventional generators
   `#1095 <https://github.com/openego/eGon-data/issues/1095>`_
+* Improve building household load assignment
+  `#350 <https://github.com/openego/powerd-data/issues/350>`_
 
 .. _PR #159: https://github.com/openego/eGon-data/pull/159
 .. _PR #703: https://github.com/openego/eGon-data/pull/703

--- a/src/egon/data/datasets/electricity_demand_timeseries/hh_buildings.py
+++ b/src/egon/data/datasets/electricity_demand_timeseries/hh_buildings.py
@@ -157,6 +157,32 @@ def match_osm_and_zensus_data(
     pd.DataFrame
         Table with cell_ids and number of missing buildings
     """
+
+    def find_adjacent_cells(row, adj_cell_radius):
+        """
+        Find adjacent cells for cell by iterating over census grid ids
+        (100mN...E...).
+
+        Parameters
+        ----------
+        row : Dataframe row
+            Dataframe row
+        adj_cell_radius : int
+            distance of cells in each direction to find cells,
+            e.g. adj_cell_radius=3 -> 7x7 cell matrix
+
+        Returns
+        -------
+        tuples of int
+            N coordinates, E coordinates in format
+            [(N_cell_1, E_cell_1), ..., (N_cell_n, E_cell_n)]
+        """
+        return [f"100mN{_[0]}E{_[1]}" for _ in np.array(
+            np.meshgrid(
+                np.arange(row.N - adj_cell_radius, row.N + adj_cell_radius + 1),
+                np.arange(row.E - adj_cell_radius, row.E + adj_cell_radius + 1)
+            )).T.reshape(-1, 2)]
+
     # count number of profiles for each cell
     profiles_per_cell = egon_hh_profile_in_zensus_cell.cell_profile_ids.apply(
         len
@@ -250,6 +276,42 @@ def match_osm_and_zensus_data(
     missing_buildings["building_count"] = missing_buildings[
         "building_count"
     ].fillna(value=building_count_fillna)
+
+    # ========== START Update profile/building rate in cells w/o bld using adjacent cells ==========
+    missing_buildings_temp = egon_hh_profile_in_zensus_cell[
+        ["cell_id", "grid_id"]].set_index("cell_id").loc[
+        missing_buildings.index.unique()]
+
+    # Extract coordinates
+    missing_buildings_temp = pd.concat(
+        [missing_buildings_temp, missing_buildings_temp.grid_id.str.extract(
+            r"100mN(\d+)E(\d+)").astype(int).rename(columns={0: "N", 1: "E"})],
+        axis=1
+    )
+
+    # Find adjacent cells for cell
+    missing_buildings_temp["cell_adj"] = missing_buildings_temp.apply(
+        find_adjacent_cells, adj_cell_radius=3, axis=1)
+    missing_buildings_temp = missing_buildings_temp.explode("cell_adj").drop(
+        columns=["grid_id", "N", "E"]).reset_index()
+
+    # Create mapping table cell -> adjacent cells
+    missing_buildings_temp = missing_buildings_temp.set_index("cell_adj").join(
+        egon_hh_profile_in_zensus_cell.set_index("grid_id").cell_id, rsuffix="_adj"
+    ).dropna().set_index("cell_id_adj")
+
+    # Calculate profile/building rate for those cells
+    profile_building_rate.name = "profile_building_rate"
+    missing_buildings_temp = missing_buildings_temp.join(
+        number_of_buildings_profiles_per_cell[["cell_id"]].join(
+            profile_building_rate).set_index("cell_id"))
+    missing_buildings_temp = missing_buildings_temp.groupby("cell_id").median().dropna()
+
+    # Update mising buildings
+    missing_buildings["building_count"] = missing_buildings.cell_profile_ids.div(
+        missing_buildings_temp.profile_building_rate).fillna(
+        missing_buildings.building_count)
+    # ========== END Update profile/building rate in cells w/o bld using adjacent cells ==========
 
     # ceil to have at least one building each cell and make type int
     missing_buildings = missing_buildings.apply(np.ceil).astype(int)

--- a/src/egon/data/datasets/electricity_demand_timeseries/hh_buildings.py
+++ b/src/egon/data/datasets/electricity_demand_timeseries/hh_buildings.py
@@ -140,9 +140,12 @@ def match_osm_and_zensus_data(
     OSM building data and hh demand profiles based on census data is compared.
     Census cells with only profiles but no osm-ids are identified to generate
     synthetic buildings. Census building count is used, if available, to define
-    number of missing buildings. Otherwise, the overall mean profile/building
-    rate is used to derive the number of buildings from the number of already
-    generated demand profiles.
+    number of missing buildings. Otherwise, we use a twofold approach for the
+    rate: first, the rate is calculated using adjacent cells (function
+    `find_adjacent_cells()`), a distance of 3 cells in each direction is used
+    by default (resulting in a 7x7 lookup matrix). As fallback, the overall
+    median profile/building rate is used to derive the number of buildings
+    from the number of already generated demand profiles.
 
     Parameters
     ----------
@@ -1089,7 +1092,8 @@ class setup(Dataset):
     there is enough households by the census data. If there are more
     profiles than buildings, all additional profiles are randomly assigned.
     Therefore, multiple profiles can be assigned to one building, making it a
-    multi-household building.
+    multi-household building. If there are no OSM buildings available,
+    synthetic ones are created (see below).
 
     **What are central assumptions during the data processing?**
 
@@ -1103,10 +1107,17 @@ class setup(Dataset):
     **Drawbacks and limitations of the data**
 
     * Missing OSM buildings in cells without census building count are
-      derived by an average rate of households/buildings applied to the
-      number of households. As only whole houses can exist, the substitute
-      is ceiled to the next higher integer. Ceiling is applied to avoid
-      rounding to amount of 0 buildings.
+      derived by an average (median) rate of households/buildings applied
+      to the number of households. We use a twofold approach for the rate:
+      first, the rate is calculated using adjacent cells (function
+      `find_adjacent_cells()`), a distance of 3 cells in each direction is
+      used by default (resulting in a 7x7 lookup matrix). For the remaining
+      cells, i.e. cells without any rate in the adjacent cells, the global
+      median rate is used.
+
+      As only whole houses can exist, the substitute is ceiled to the next
+      higher integer. Ceiling is applied to avoid rounding to amount of 0
+      buildings.
 
     * As this datasets is a cascade after profile assignement at census
       cells also check drawbacks and limitations in hh_profiles.py.

--- a/src/egon/data/datasets/electricity_demand_timeseries/hh_buildings.py
+++ b/src/egon/data/datasets/electricity_demand_timeseries/hh_buildings.py
@@ -972,9 +972,9 @@ class setup(Dataset):
     #:
     name: str = "Demand_Building_Assignment"
     #:
-    version: str = "0.0.5"
+    version: str = "0.0.6"
     #:
-    tasks = (map_houseprofiles_to_buildings, get_building_peak_loads)
+    tasks = (map_houseprofiles_to_buildings, create_buildings_profiles_stats, get_building_peak_loads)
 
     def __init__(self, dependencies):
         super().__init__(

--- a/src/egon/data/datasets/osm_buildings_streets/__init__.py
+++ b/src/egon/data/datasets/osm_buildings_streets/__init__.py
@@ -184,7 +184,7 @@ class OsmBuildingsStreets(Dataset):
     #:
     name: str = "OsmBuildingsStreets"
     #:
-    version: str = "0.0.6"
+    version: str = "0.0.7"
 
     def __init__(self, dependencies):
         super().__init__(

--- a/src/egon/data/datasets/osm_buildings_streets/__init__.py
+++ b/src/egon/data/datasets/osm_buildings_streets/__init__.py
@@ -42,8 +42,8 @@ def filter_buildings_residential():
 
 def extend_buildings_residential():
     print(
-        "Extend residential buildings by commercial/retail buildings in cells "
-        "with census population but without buildings..."
+        "Extend residential buildings by commercial/retail/office/hotel "
+        "buildings in cells with census population but without buildings..."
     )
     execute_sql_script("osm_buildings_extend_residential.sql")
 
@@ -144,9 +144,9 @@ class OsmBuildingsStreets(Dataset):
       * Residential buildings: `openstreetmap.osm_buildings_residential`
         * 1st step: Filter by tags (see `osm_buildings_filter_residential.sql`)
         * 2nd step: Table is extended by finding census cells with population
-          but no residential buildings and extended by commercial/retail buildings
-          (see `osm_buildings_extend_residential.sql`) since they often include
-          apartments as well.
+          but no residential buildings and extended by commercial/retail/office/
+          hotel buildings (see `osm_buildings_extend_residential.sql`) since they
+          often include apartments as well.
     * Extract amenities and filter using relevant tags, e.g. shops and restaurants,
       see script `osm_amenities_shops_preprocessing.sql` for the full list of tags.
       Resulting table: `openstreetmap.osm_amenities_shops_filtered`

--- a/src/egon/data/datasets/osm_buildings_streets/__init__.py
+++ b/src/egon/data/datasets/osm_buildings_streets/__init__.py
@@ -40,6 +40,14 @@ def filter_buildings_residential():
     execute_sql_script("osm_buildings_filter_residential.sql")
 
 
+def extend_buildings_residential():
+    print(
+        "Extend residential buildings by commercial/retail buildings in cells "
+        "with census population but without buildings..."
+    )
+    execute_sql_script("osm_buildings_extend_residential.sql")
+
+
 def create_buildings_filtered_zensus_mapping():
     print(
         "Create census mapping table for filtered buildings in populated areas..."
@@ -134,6 +142,11 @@ class OsmBuildingsStreets(Dataset):
       * All buildings: `openstreetmap.osm_buildings`
       * Filtered buildings: `openstreetmap.osm_buildings_filtered`
       * Residential buildings: `openstreetmap.osm_buildings_residential`
+        * 1st step: Filter by tags (see `osm_buildings_filter_residential.sql`)
+        * 2nd step: Table is extended by finding census cells with population
+          but no residential buildings and extended by commercial/retail buildings
+          (see `osm_buildings_extend_residential.sql`) since they often include
+          apartments as well.
     * Extract amenities and filter using relevant tags, e.g. shops and restaurants,
       see script `osm_amenities_shops_preprocessing.sql` for the full list of tags.
       Resulting table: `openstreetmap.osm_amenities_shops_filtered`
@@ -181,6 +194,7 @@ class OsmBuildingsStreets(Dataset):
             tasks=(
                 preprocessing,
                 {filter_buildings, filter_buildings_residential},
+                extend_buildings_residential,
                 extract_buildings_filtered_amenities,
                 {
                     create_buildings_filtered_zensus_mapping,

--- a/src/egon/data/datasets/osm_buildings_streets/osm_buildings_extend_residential.sql
+++ b/src/egon/data/datasets/osm_buildings_streets/osm_buildings_extend_residential.sql
@@ -1,0 +1,36 @@
+/*
+ * Original Autor: nesnoj (jonathan.amme@rl-institut.de)
+*/
+
+--------------------------------------------------------------------------------
+-- Extend residential buildings by finding census cells with population but   --
+-- no residential buildings before in osm_buildings_filter_residential.sql .  --
+-- Mark commercial and retail buildings as residential in those cells.        --
+--------------------------------------------------------------------------------
+
+INSERT INTO openstreetmap.osm_buildings_residential
+	SELECT *
+	FROM openstreetmap.osm_buildings_filtered
+	WHERE id IN (
+		SELECT id FROM (
+			-- get buildings from filtered table in census cells (by centroid)
+			SELECT
+				bld.id,
+				zensus.grid_id,
+				zensus.zensus_population_id AS cell_id
+			FROM openstreetmap.osm_buildings_filtered bld
+			LEFT JOIN society.egon_destatis_zensus_apartment_building_population_per_ha zensus
+			ON ST_Within(bld.geom_point, zensus.geom)
+			WHERE building in ('commercial', 'retail')
+			AND zensus.zensus_population_id in (
+				-- census cell ids which have population but no res. buildings
+				SELECT zensus.zensus_population_id
+				FROM society.egon_destatis_zensus_apartment_building_population_per_ha zensus
+				LEFT OUTER JOIN openstreetmap.osm_buildings_residential bld
+				ON ST_Intersects(bld.geom_building, zensus.geom)
+				WHERE bld.id IS NULL
+			)
+		) bld2
+		WHERE bld2.id IS NOT NULL AND bld2.grid_id IS NOT NULL
+	)
+;

--- a/src/egon/data/datasets/osm_buildings_streets/osm_buildings_extend_residential.sql
+++ b/src/egon/data/datasets/osm_buildings_streets/osm_buildings_extend_residential.sql
@@ -5,7 +5,8 @@
 --------------------------------------------------------------------------------
 -- Extend residential buildings by finding census cells with population but   --
 -- no residential buildings before in osm_buildings_filter_residential.sql .  --
--- Mark commercial and retail buildings as residential in those cells.        --
+-- Mark commercial, retail, office, hotel buildings as residential in those   --
+-- cells.                                                                     --
 --------------------------------------------------------------------------------
 
 INSERT INTO openstreetmap.osm_buildings_residential
@@ -21,7 +22,7 @@ INSERT INTO openstreetmap.osm_buildings_residential
 			FROM openstreetmap.osm_buildings_filtered bld
 			LEFT JOIN society.egon_destatis_zensus_apartment_building_population_per_ha zensus
 			ON ST_Within(bld.geom_point, zensus.geom)
-			WHERE building in ('commercial', 'retail')
+			WHERE building in ('commercial', 'retail', 'office', 'hotel')
 			AND zensus.zensus_population_id in (
 				-- census cell ids which have population but no res. buildings
 				SELECT zensus.zensus_population_id

--- a/src/egon/data/datasets/osm_buildings_streets/osm_buildings_filter.sql
+++ b/src/egon/data/datasets/osm_buildings_streets/osm_buildings_filter.sql
@@ -65,6 +65,7 @@ CREATE TABLE openstreetmap.osm_buildings_filtered as
         or bld.building like 'transformer_tower'
         or bld.building like 'military'
         or bld.building like 'gatehouse'
+        or bld.building like 'cohousing'
         or bld.amenity like 'bar'
         or bld.amenity like 'biergarten'
         or bld.amenity like 'cafe'
@@ -91,9 +92,18 @@ CREATE TABLE openstreetmap.osm_buildings_filtered as
         or bld.amenity like 'dentist'
         or bld.amenity like 'doctors'
         or bld.amenity like 'hospital'
-        or bld.amenity like 'nursing_home'
         or bld.amenity like 'pharmacy'
-        or bld.amenity like 'social_facility'
+
+        -- retirement and assisted homes
+        or bld.amenity like 'retirement_home'
+        or (
+            bld.amenity like 'social_facility'
+			and tags::hstore -> 'social_facility' in ('nursing_home', 'assisted_living', 'group_home')
+        )
+        or bld.amenity like 'nursing_home'
+        or bld.amenity like 'assisted_living'
+        or bld.amenity like 'group_home'
+
         or bld.amenity like 'veterinary'
         or bld.amenity like 'arts_centre'
         or bld.amenity like 'brothel'

--- a/src/egon/data/datasets/osm_buildings_streets/osm_buildings_filter.sql
+++ b/src/egon/data/datasets/osm_buildings_streets/osm_buildings_filter.sql
@@ -22,6 +22,7 @@ CREATE TABLE openstreetmap.osm_buildings_filtered as
         or bld.building like 'semidetached_house'
         or bld.building like 'static_caravan'
         or bld.building like 'terrace'
+        or bld.building like 'terraced_house'
         or bld.building like 'commercial'
         or bld.building like 'industrial'
         or bld.building like 'kiosk'

--- a/src/egon/data/datasets/osm_buildings_streets/osm_buildings_filter_residential.sql
+++ b/src/egon/data/datasets/osm_buildings_streets/osm_buildings_filter_residential.sql
@@ -17,7 +17,10 @@ CREATE TABLE openstreetmap.osm_buildings_residential as
         or bld.building like 'farm'
         or bld.building like 'house'
         or bld.building like 'residential'
-        or bld.building like 'semidetached_house';
+        or bld.building like 'semidetached_house'
+        or bld.building like 'terrace'
+        or bld.building like 'dormitory'
+        or bld.building like 'terraced_house';
 
 ALTER TABLE openstreetmap.osm_buildings_residential
     ADD CONSTRAINT osm_buildings_residential_id_pkey PRIMARY KEY (id);

--- a/src/egon/data/datasets/osm_buildings_streets/osm_buildings_filter_residential.sql
+++ b/src/egon/data/datasets/osm_buildings_streets/osm_buildings_filter_residential.sql
@@ -20,7 +20,17 @@ CREATE TABLE openstreetmap.osm_buildings_residential as
         or bld.building like 'semidetached_house'
         or bld.building like 'terrace'
         or bld.building like 'dormitory'
-        or bld.building like 'terraced_house';
+        or bld.building like 'terraced_house'
+
+        -- retirement and assisted homes
+        or bld.amenity like 'retirement_home'
+        or (
+            bld.amenity like 'social_facility'
+			and tags::hstore -> 'social_facility' in ('nursing_home', 'assisted_living', 'group_home')
+        )
+        or bld.amenity like 'nursing_home'
+        or bld.amenity like 'assisted_living'
+        or bld.amenity like 'group_home';
 
 ALTER TABLE openstreetmap.osm_buildings_residential
     ADD CONSTRAINT osm_buildings_residential_id_pkey PRIMARY KEY (id);


### PR DESCRIPTION
Fixes #350

Improve building household load assignment:
- **Extend OSM tags**: regular building types and retirement and assisted homes
- Use **commercial and retail buildings as fallback** in populated cells without res. buildings
- Use **building parts in hh load profile allocation** instead of centroids: Buildings are clipped with census cells and resulting parts are now used for allocation instead of centroids only resulting in less synthetic buildings to be created. This reduced the total count of synth. buildings from 14k to 6.4k (SH run).
- **Adjust the number of synth. buildings created in a cell**: Use median of profile/building rate of adjacent cells instead of the global rate median to better represent the local conditions. This did not change the total count of synth. buildings (6.4k -> 5.6k) significantly but alters the regional distribution.
- Add **table with household profile type counts per building**

## Before merging into `dev`-branch, please make sure that

- [ ] the `CHANGELOG.rst` was updated.
- [x] new and adjusted code is formated using `black` and `isort`.
- [x] the `Dataset`-version is updated when existing datasets are adjusted.
- [ ] the branch was merged into the
      `continuous-integration/run-everything-over-the-weekend`-branch.
- [ ] the workflow is running successful in `test mode`.
- [ ] the workflow is running successful in `Everything` mode.
