### PR TITLE
Add a very small buffer when joining etrago heat buses heat grids

### DIFF
--- a/src/egon/data/datasets/heat_etrago/__init__.py
+++ b/src/egon/data/datasets/heat_etrago/__init__.py
@@ -332,7 +332,10 @@ def insert_central_direct_heat(scenario):
         {targets['heat_buses']['table']}
         JOIN {sources['district_heating_areas']['schema']}.
             {sources['district_heating_areas']['table']}
-        ON ST_Transform(ST_Centroid(geom_polygon), 4326) = geom
+        ON ST_Intersects(
+        ST_Transform(
+        ST_Buffer(ST_Centroid(geom_polygon),
+         0.0000001), 4326), geom)
         WHERE carrier = 'central_heat'
         AND scenario = '{scenario}'
         AND scn_name = '{scenario}'

--- a/src/egon/data/datasets/heat_etrago/power_to_heat.py
+++ b/src/egon/data/datasets/heat_etrago/power_to_heat.py
@@ -465,7 +465,9 @@ def assign_electrical_bus(heat_pumps, carrier, scenario, multiple_per_mv_grid=Fa
         {targets['heat_buses']['table']}
         JOIN {sources['district_heating_areas']['schema']}.
             {sources['district_heating_areas']['table']}
-        ON ST_Transform(ST_Centroid(geom_polygon), 4326) = geom
+        ON ST_Intersects(
+        ST_Transform(ST_Buffer(
+        ST_Centroid(geom_polygon), 0.0000001), 4326), geom)
         WHERE carrier = 'central_heat'
         AND scenario='{scenario}'
         AND scn_name = '{scenario}'


### PR DESCRIPTION
Somehow the centroids of one district heating grid was not exactly at the location of the bus in etrago but a couple of centimeters away from it. 
To prevent such problems, I added a very small buffer <1m when joining the geometries. 
The task was already running successful on the server. 
