### PR TITLE
Fixes/#388 missing rural heat supply

### DIFF
--- a/src/egon/data/datasets/heat_supply/__init__.py
+++ b/src/egon/data/datasets/heat_supply/__init__.py
@@ -182,7 +182,7 @@ class HeatSupply(Dataset):
     def __init__(self, dependencies):
         super().__init__(
             name="HeatSupply",
-            version="0.0.11",
+            version="0.0.12",
             dependencies=dependencies,
             tasks=(
                 create_tables,

--- a/src/egon/data/datasets/heat_supply/individual_heating.py
+++ b/src/egon/data/datasets/heat_supply/individual_heating.py
@@ -563,7 +563,7 @@ def cascade_per_technology(
                     FROM {sources['scenario_capacities']['schema']}.
                     {sources['scenario_capacities']['table']} a
                     WHERE scenario_name = '{scenario}'
-                    AND carrier IN ('rural_air_heat_pump', 'rural_ground_heat_pump')
+                    AND carrier = 'rural_heat_pump'
                     """
             )
 


### PR DESCRIPTION
Fixes #388  .

There were mainly two groups of problems that are solved here: 
- the target value for rural heat pumps in `heat_supply.individual_heating` was looking for an old carrier name and therefore always returned 0
- other technologies apart from rural heat pumps were not part of the `heat_etrago.supply task`, they have been in the intermediate table for rural heat supply but were not copied to the tables for etrago

Both issues seem to be fixed now. I tested it with a local run for Schleswig-Holstein and can see the expected capacities in the eTraGo tables. 
