### PR TITLE
Set heat pump carrier in status2019 to the same one used in eGon100RE

### DIFF
--- a/src/egon/data/datasets/scenario_capacities.py
+++ b/src/egon/data/datasets/scenario_capacities.py
@@ -132,7 +132,7 @@ def insert_capacities_status2019():
         (component, carrier, capacity, nuts, scenario_name)
         VALUES (
             'link',
-            'residential_rural_heat_pump',
+            'rural_heat_pump',
             {rural_heat_capacity},
             'DE',
             'status2019'            
@@ -858,7 +858,7 @@ class ScenarioCapacities(Dataset):
     def __init__(self, dependencies):
         super().__init__(
             name="ScenarioCapacities",
-            version="0.0.16",
+            version="0.0.17",
             dependencies=dependencies,
             tasks=tasks,
         )


### PR DESCRIPTION
Fixes problems in the later tasks individual_heating.determine-hp-capacity-2019-mvgd-bulk#.

Before, the heat pump capacity in status2019 was always 0 since we updated the carrier name that is filtered in the heat supply dataset. 

I already tested it for Schleswig-Holstein