### PR TITLE
Correct Carrier naming of H2_to_CH4 + No Methanisation from saltcaver…

### DIFF
--- a/src/egon/data/datasets/hydrogen_etrago/h2_to_ch4.py
+++ b/src/egon/data/datasets/hydrogen_etrago/h2_to_ch4.py
@@ -65,7 +65,7 @@ def insert_h2_to_ch4_to_h2():
         sql_H2_buses = f"""
                 SELECT bus_id, x, y, ST_Transform(geom, 32632) as geom
                 FROM {target_buses["schema"]}.{target_buses["table"]} 
-                WHERE carrier in ('H2','H2_saltcavern')
+                WHERE carrier in ('H2')
                 AND scn_name = '{scn_name}' AND country = 'DE'
                 """    
         CH4_buses = gpd.read_postgis(sql_CH4_buses, con)
@@ -111,7 +111,7 @@ def insert_h2_to_ch4_to_h2():
         
         scn_params = get_sector_parameters("gas", scn_name)
         technology = [CH4_to_H2_links, H2_to_CH4_links]
-        links_carriers = ["CH4_to_H2", "CH4_to_H2"]
+        links_carriers = ["CH4_to_H2", "H2_to_CH4"]
         
         # Write new entries
         for table, carrier in zip(technology, links_carriers):

--- a/src/egon/data/datasets/hydrogen_etrago/storage.py
+++ b/src/egon/data/datasets/hydrogen_etrago/storage.py
@@ -45,7 +45,7 @@ def insert_H2_overground_storage():
             f"""
             SELECT bus_id, scn_name, geom
             FROM {sources['buses']['schema']}.
-            {sources['buses']['table']} WHERE carrier = 'H2'
+            {sources['buses']['table']} WHERE carrier IN ('H2', 'H2_grid')
             AND scn_name = '{scn_name}' AND country = 'DE'""",
             index_col="bus_id",
         )


### PR DESCRIPTION
Three adjustments regarding the H2_part were made:
- [ ] Correct carrier naming of H2_to_CH4-links. Both carriers (H2_to_CH4/CH4_to_H2) are now implemented into database
- [ ] Methanisation links are just created between "H2"-Busses and nearest CH4 Busses. No Methanisation from saltcaverns any more
- [ ] H2-Overground storage should be implemented for both H2 and H2-grid_buses
