### PR TITLE
Map buildings on mvgd using the first scenario in the list of scenarios

### DIFF
--- a/src/egon/data/datasets/electricity_demand_timeseries/cts_buildings.py
+++ b/src/egon/data/datasets/electricity_demand_timeseries/cts_buildings.py
@@ -257,7 +257,7 @@ class CtsDemandBuildings(Dataset):
     def __init__(self, dependencies):
         super().__init__(
             name="CtsDemandBuildings",
-            version="0.0.5",
+            version="0.0.6",
             dependencies=dependencies,
             tasks=(
                 cts_buildings,

--- a/src/egon/data/datasets/electricity_demand_timeseries/mapping.py
+++ b/src/egon/data/datasets/electricity_demand_timeseries/mapping.py
@@ -2,7 +2,7 @@ from sqlalchemy import Column, Integer, String
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.types import Boolean
 
-from egon.data import db
+from egon.data import config, db
 
 Base = declarative_base()
 
@@ -19,6 +19,7 @@ class EgonMapZensusMvgdBuildings(Base):
     electricity = Column(Boolean, index=True)
     heat = Column(Boolean, index=True)
 
+scenarios = config.settings()["egon-data"]["--scenarios"]
 
 def map_all_used_buildings():
     """This function maps all used buildings from OSM and synthetic ones."""
@@ -50,7 +51,7 @@ def map_all_used_buildings():
                 boundaries.egon_map_zensus_grid_districts AS mvgd
             WHERE bld.id = peak.building_id
 -- Buildings do not change in the scenarios
-                AND peak.scenario = 'eGon2035'
+                AND peak.scenario = '{scenarios[0]}'
                 AND ST_Within(bld.geom_point, zensus.geom)
                 AND mvgd.zensus_population_id = zensus.id;
 


### PR DESCRIPTION
Deals with #400 

The rural heat demand was too low because of the missing mapping of CTS buildings to mvgd. 
All CTS buildings got a (correct) heat demand, but all pure CTS buildings were not matched to a mvgd in `boundaries.egon_map_zensus_mvgd_buildings` so the demand was dropped when aggregating it on mvgd. 
